### PR TITLE
(fix) Erase space before 8888

### DIFF
--- a/server.js
+++ b/server.js
@@ -31,6 +31,6 @@ app.use(function(req, res) {
 });
 
 app.listen(app.get('port'), function() {
-    console.log("Express started on http://localhost: " +
+    console.log("Express started on http://localhost:" +
         app.get('port') + '; press Ctrl-C to terminate.');
 });


### PR DESCRIPTION
Users now can access to localhost:8888 by simply copying the address given by the terminal
